### PR TITLE
upgrade from SHA1 to SHA256

### DIFF
--- a/cache-http.sh
+++ b/cache-http.sh
@@ -35,9 +35,9 @@ curl \
     -x "$INPUT_HTTP_PROXY" \
     "$INPUT_CACHE_HTTP_API/health"
 
-shaLockfile=$(openssl sha1 "$INPUT_LOCK_FILE" |awk '{print $2}')
-shaInstallCommand=$(echo "$INPUT_INSTALL_COMMAND"|openssl sha1|awk '{print $2}')
-shaDestinationFolder=$(echo "$INPUT_DESTINATION_FOLDER"|openssl sha1|awk '{print $2}')
+shaLockfile=$(openssl sha256 "$INPUT_LOCK_FILE" |awk '{print $2}')
+shaInstallCommand=$(echo "$INPUT_INSTALL_COMMAND"|openssl sha256|awk '{print $2}')
+shaDestinationFolder=$(echo "$INPUT_DESTINATION_FOLDER"|openssl sha256|awk '{print $2}')
 
 tarFile="$RUNNER_OS-$INPUT_VERSION-$shaInstallCommand-$shaLockfile-$shaDestinationFolder.tar.gz"
 


### PR DESCRIPTION
While there's not a known issue with the use of SHA1 here, it's
recommended to move away from it. SHA256 is already well-supported and
performs well enough, so we switch to it for a more future-proof
solution.

This change will will cause a one-time cache-miss for all existing
assets.

Fixes: #12
